### PR TITLE
Add an option to not offer manual enrollment for DEP machines.

### DIFF
--- a/payload/Library/umad/Resources/umad
+++ b/payload/Library/umad/Resources/umad
@@ -332,6 +332,10 @@ def get_parsed_options():
     o.add_option('--logopath',
                  default='company_logo.png',
                  help=('Optional: Path to company logo.'))
+    o.add_option('--disablemanualenrollmentfordep', default=False,
+                 help='Optional: Disable the manual enrollment button for '
+                 'DEP devices',
+                 action='store_true')
     o.add_option('--manualenrollmenturl',
                  default='https://apple.com',
                  help=('Required: Manual Enrollment URL.'))
@@ -771,20 +775,22 @@ def main():
             # If the cutoff date is over, get stupidly aggressive
 
             # Disable all buttons so the user cannot exit out of the
-            # application, and have the manualenrollment button appear
+            # application.
             umad.views['button.ok'].setHidden_(True)
             umad.views['button.understand'].setHidden_(True)
 
             # Show the manual enrollment UI for emergency purposes
-            umad.views['button.manualenrollment'].setHidden_(False)
-            umad.views['field.manualenrollmenttext'].setHidden_(False)
+            # if allowed.
+            if not opts.disablemanualenrollmentfordep:
+                umad.views['button.manualenrollment'].setHidden_(False)
+                umad.views['field.manualenrollmenttext'].setHidden_(False)
+                umad.views['field.depfailuretext'].setHidden_(False)
+                umad.views['field.depfailuretext'].setStringValue_(
+                    manualenroll_h1_text)
+                umad.views['field.depfailuresubtext'].setHidden_(False)
+                umad.views['field.depfailuresubtext'].setStringValue_(
+                    manualenroll_h2_text)
             umad.views['image.nagscreen'].setHidden_(True)
-            umad.views['field.depfailuretext'].setHidden_(False)
-            umad.views['field.depfailuretext'].setStringValue_(
-                manualenroll_h1_text)
-            umad.views['field.depfailuresubtext'].setHidden_(False)
-            umad.views['field.depfailuresubtext'].setStringValue_(
-                manualenroll_h2_text)
 
             # Bring back umad to the foreground, every 10 seconds
             timer = float(opts.timerelapsed)
@@ -905,14 +911,16 @@ def main():
         umad.views['field.depfailuresubtext'].setStringValue_(
             manualenroll_h2_text)
     elif date_diff_seconds <= 0:
-        umad.views['field.manualenrollmenttext'].setHidden_(True)
         umad.views['image.nagscreen'].setHidden_(False)
-        umad.views['field.depfailuretext'].setHidden_(False)
-        umad.views['field.depfailuretext'].setStringValue_(
-            opts.depfailuretext)
-        umad.views['field.depfailuresubtext'].setHidden_(False)
-        umad.views['field.depfailuresubtext'].setStringValue_(
-            opts.depfailuresubtext)
+        umad.views['field.manualenrollmenttext'].setHidden_(True)
+
+        if not opts.disablemanualenrollmentfordep:
+            umad.views['field.depfailuretext'].setHidden_(False)
+            umad.views['field.depfailuretext'].setStringValue_(
+                opts.depfailuretext)
+            umad.views['field.depfailuresubtext'].setHidden_(False)
+            umad.views['field.depfailuresubtext'].setStringValue_(
+                opts.depfailuresubtext)
 
     # Do one final MDM check to instantly update the UI for UAMDM
     check_mdm_status(True)


### PR DESCRIPTION
Long after an initial enrollment push has finished, umad still fills a role by providing an automated remediation helper for when someone exercises their admin rights and removes their device profile, either on their own, or at the direction of support.

One problem that can arise is that, because the cutoff date has long since expired, the manual enrollment option is offered. If a user goes for this, they then will continue to receive the DEP notification, and be thwarted when they try to follow its instructions and enroll (again, to the same MDM...)

Please find herein a minimal change to allow skipping the manual enrollment option under these circumstances.
Specifically:
- cutoff date has passed
- the notification has been delivered
- the device _is_ DEP capable
- the similar option to always show the manual enrollment button has _not_ been used
- a manual enrollment URL has been set.

This is somewhat convoluted in reasoning about, although the diff is somewhat minimal.

If this isn't a viable approach, please give me some suggestions for either refactoring the existing code to handle this better or perhaps another strategy to solve this.

Thanks!