### PR TITLE
fix: 12.3 issue for profiles show

### DIFF
--- a/payload/Library/umad/Resources/umad_check_dep_record
+++ b/payload/Library/umad/Resources/umad_check_dep_record
@@ -45,7 +45,25 @@ def has_dep_activation_record(plist_path):
         if os.path.isfile(bad_record):
             os.remove(bad_record)
         run = subprocess.Popen(cmd, preexec_fn=os.setpgrp)
-    if get_os_version() >= LooseVersion('10.12'):
+    if get_os_version() >= LooseVersion("12.3"):
+        # running cmd on 12.3 will result in err 90% of the time but need to run at least
+        # once to write these files.
+        good_record = '/private/var/db/ConfigurationProfiles/Settings/.cloudConfigRecordFound'
+        bad_record = '/private/var/db/ConfigurationProfiles/Settings/.cloudConfigRecordNotFound'
+        if os.path.exists(bad_record):
+            return False
+        try:
+            with open(good_record, "rb") as file:
+                plist = plistlib.load(file)
+        except:  # noqa
+            return False
+        if "CloudConfigFetchError" in plist:
+            # This happens for invalid serial numbers
+            return False
+        else:
+            copyfile(good_record, plist_path)
+            return True
+    elif get_os_version() >= LooseVersion("10.12") and get_os_version() < LooseVersion("12.3"~):
         if err:
             return False
         try:


### PR DESCRIPTION
From the 12.3 profiles man page:
```
     show       -type profile_type -user user_name -output output_path
                Show expanded information for profiles.   For an enrollment, this will show the current DEP configuration, and the call may be rate limited to once every 23 hours.
```
umad currently relies on this command and will detect DEP status as false if the command returns an error. If the command is tried again within 23 hours it will result in an error.

This fix relies on detecting the dot files that this command alters located in `/private/var/db/ConfigurationProfiles/Settings`

From our testing a machine that requires manual enrollment will always have a `.cloudConfigRecordNotFound` file. This can be because the machine is not in DEP or because the MDM is not assigned, which does get removed when the command completes and the machine does have a valid MDM assigned.

VMs with invalid serial numbers seem to result in returning a different error as shown:

```
% cat .cloudConfigRecordFound 
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>CloudConfigFetchError</key>
	<dict>
		<key>__Error__</key>
...
```

With this detection, there is potentially a small gap during the first 23 hours after the change where the `.cloudConfigRecordFound` file will contain invalid information. However, umad does not take this data into consideration.

This should satisfy #44 